### PR TITLE
add_device_info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,37 @@
+# Android Studio / IntelliJ IDEA
+.idea/
 *.iml
-.gradle
-/local.properties
-/.idea/caches
-/.idea/libraries
-/.idea/modules.xml
-/.idea/workspace.xml
-/.idea/navEditor.xml
-/.idea/assetWizardSettings.xml
+*.iws
+*.ipr
+/out
+.shelf
 .DS_Store
-/build
-/captures
+
+# Gradle
+.gradle/
+/build/
+/captures/
 .externalNativeBuild
 .cxx
 local.properties
+
+# Android Test / Device
+captures/
+/google_services.json
+
+# Log files
+*.log
+
+# Built APKs/AARs
+*.apk
+*.aar
+
+# NDK
+obj/
+
+# Keystore files
+*.jks
+*.keystore
+
+# Others
+/local.properties

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)

--- a/app/src/main/java/com/example/checkdrminfo/MainActivity.kt
+++ b/app/src/main/java/com/example/checkdrminfo/MainActivity.kt
@@ -2,6 +2,7 @@ package com.example.checkdrminfo
 
 import android.media.MediaDrm
 import android.media.MediaDrmException
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
@@ -24,10 +25,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -41,8 +40,13 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.media3.common.C
 import com.example.checkdrminfo.ui.theme.CheckDrmInfoTheme
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import java.util.UUID
 
 class MainActivity : ComponentActivity() {
@@ -61,17 +65,64 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+data class DRMInfoState(
+    val widevineInfo: Pair<Boolean, String>? = null,
+    val clearKeyInfo: Pair<Boolean, String>? = null,
+    val playReadyInfo: Pair<Boolean, String>? = null,
+    val deviceInfo: DeviceInfo = DeviceInfo()
+)
+
+data class DeviceInfo(
+    val model: String = try { Build.MODEL } catch (_: Exception) { "Unknown" },
+    val manufacturer: String = try { Build.MANUFACTURER } catch (_: Exception) { "Unknown" },
+    val androidVersion: String = try { Build.VERSION.RELEASE } catch (_: Exception) { "Unknown" },
+    val sdkInt: Int = try { Build.VERSION.SDK_INT } catch (_: Exception) { 0 },
+    val fingerprint: String = try { Build.FINGERPRINT } catch (_: Exception) { "Unknown" }
+)
+
+class DRMViewModel : ViewModel() {
+    private val _uiState = MutableStateFlow(DRMInfoState())
+    val uiState: StateFlow<DRMInfoState> = _uiState.asStateFlow()
+
+    private val drmChecker = DRMChecker()
+
+    init {
+        refreshDRMInfo()
+    }
+
+    fun refreshDRMInfo() {
+        _uiState.value = _uiState.value.copy(
+            widevineInfo = drmChecker.checkWidevineSupport(),
+            clearKeyInfo = drmChecker.checkClearKeySupport(),
+            playReadyInfo = drmChecker.checkPlayReadySupport()
+        )
+    }
+}
+
 @Composable
-fun DRMInfoScreen(modifier: Modifier = Modifier) {
-    var widevineInfo by remember { mutableStateOf<Pair<Boolean, String>?>(null) }
-    var clearKeyInfo by remember { mutableStateOf<Pair<Boolean, String>?>(null) }
-    var playReadyInfo by remember { mutableStateOf<Pair<Boolean, String>?>(null) }
+fun DRMInfoScreen(
+    modifier: Modifier = Modifier,
+    viewModel: DRMViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
 
-    val drmChecker = remember { DRMChecker() }
-    widevineInfo = drmChecker.checkWidevineSupport()
-    clearKeyInfo = drmChecker.checkClearKeySupport()
-    playReadyInfo = drmChecker.checkPlayReadySupport()
+    DRMInfoContent(
+        modifier = modifier,
+        widevineInfo = uiState.widevineInfo,
+        clearKeyInfo = uiState.clearKeyInfo,
+        playReadyInfo = uiState.playReadyInfo,
+        deviceInfo = uiState.deviceInfo
+    )
+}
 
+@Composable
+fun DRMInfoContent(
+    modifier: Modifier = Modifier,
+    widevineInfo: Pair<Boolean, String>?,
+    clearKeyInfo: Pair<Boolean, String>?,
+    playReadyInfo: Pair<Boolean, String>?,
+    deviceInfo: DeviceInfo = DeviceInfo()
+) {
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -88,6 +139,16 @@ fun DRMInfoScreen(modifier: Modifier = Modifier) {
         )
         Spacer(modifier = Modifier.height(16.dp))
 
+        DeviceInfoSection(deviceInfo)
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = "DRM Support",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
         DRMCheckItem(
             drmName = "Widevine",
             isSupported = widevineInfo?.first,
@@ -102,6 +163,38 @@ fun DRMInfoScreen(modifier: Modifier = Modifier) {
             drmName = "PlayReady",
             isSupported = playReadyInfo?.first,
             details = playReadyInfo?.second
+        )
+    }
+}
+
+@Composable
+fun DeviceInfoSection(deviceInfo: DeviceInfo) {
+    Column {
+        Text(
+            text = "Device Info",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        DeviceInfoItem("Manufacturer", deviceInfo.manufacturer)
+        DeviceInfoItem("Model", deviceInfo.model)
+        DeviceInfoItem("Android Version", deviceInfo.androidVersion)
+        DeviceInfoItem("SDK Level", deviceInfo.sdkInt.toString())
+        DeviceInfoItem("Fingerprint", deviceInfo.fingerprint)
+    }
+}
+
+@Composable
+fun DeviceInfoItem(label: String, value: String) {
+    Row(modifier = Modifier.padding(vertical = 4.dp)) {
+        Text(
+            text = "$label: ",
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Bold
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyLarge
         )
     }
 }
@@ -144,17 +237,19 @@ fun DRMCheckItem(drmName: String, isSupported: Boolean?, details: String?) {
 
 class DRMChecker {
 
-    private val TAG = "DRMChecker"
-    private val WIDEVINE_UUID = C.WIDEVINE_UUID
-    private val CLEARKEY_UUID = C.CLEARKEY_UUID
-    private val PLAYREADY_UUID = C.PLAYREADY_UUID
+    companion object {
+        private const val TAG = "DRMChecker"
+        private val WIDEVINE_UUID = C.WIDEVINE_UUID
+        private val CLEARKEY_UUID = C.CLEARKEY_UUID
+        private val PLAYREADY_UUID = C.PLAYREADY_UUID
+    }
 
     fun checkWidevineSupport(): Pair<Boolean, String> {
         val result = checkDrmSupport(WIDEVINE_UUID, "Widevine") { mediaDrm ->
             val securityLevel = mediaDrm.getPropertyString("securityLevel")
-            val widevineL1 = securityLevel.equals("L1", true)
-            val widevineL2 = securityLevel.equals("L2", true)
-            val widevineL3 = securityLevel.equals("L3", true)
+            val widevineL1 = securityLevel.equals("L1", ignoreCase = true)
+            val widevineL2 = securityLevel.equals("L2", ignoreCase = true)
+            val widevineL3 = securityLevel.equals("L3", ignoreCase = true)
             val hdcpLevel = try {
                 mediaDrm.getPropertyString("hdcpLevel") // Get HDCP Level
             } catch (e: MediaDrmException) {
@@ -233,6 +328,22 @@ class DRMCheckItemPreviewParameterProvider : PreviewParameterProvider<Triple<Str
 
 @Preview(showBackground = true)
 @Composable
+fun DeviceInfoSectionPreview() {
+    CheckDrmInfoTheme {
+        DeviceInfoSection(
+            deviceInfo = DeviceInfo(
+                model = "Pixel 7",
+                manufacturer = "Google",
+                androidVersion = "14",
+                sdkInt = 34,
+                fingerprint = "google/cheetah/cheetah:14/UP1A.231005.007/10754064:user/release-keys"
+            )
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
 fun DRMCheckItemPreview(@PreviewParameter(DRMCheckItemPreviewParameterProvider::class) params: Triple<String, Boolean?, String?>) {
     CheckDrmInfoTheme {
         DRMCheckItem(drmName = params.first, isSupported = params.second, details = params.third)
@@ -243,38 +354,26 @@ fun DRMCheckItemPreview(@PreviewParameter(DRMCheckItemPreviewParameterProvider::
 @Composable
 fun DRMInfoScreenPreview() {
     CheckDrmInfoTheme {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .padding(16.dp)
+        DRMInfoContent(
+            modifier = Modifier,
+            widevineInfo = Pair(true, "Security Level: L1\nWidevine L1 support: true\nWidevine L2 support: false\nWidevine L3 support: false"),
+            clearKeyInfo = Pair(true, "ClearKey CDM is present."),
+            playReadyInfo = Pair(false, "PlayReady is NOT supported on this device."),
+            deviceInfo = DeviceInfo("Pixel 7", "Google", "14", 34, "google/cheetah/cheetah:14/UP1A.231005.007/10754064:user/release-keys")
         )
-        {
-            Text(
-                text = buildAnnotatedString {
-                    pushStyle(SpanStyle(fontWeight = FontWeight.Bold, fontSize = 30.sp))
-                    append("DRM Check\n")
-                    pop()
-                },
-                modifier = Modifier.fillMaxWidth()
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            DRMCheckItem(
-                drmName = "Widevine",
-                isSupported = true,
-                details = "Security Level: L1\nWidevine L1 support: true\nWidevine L2 support: false\nWidevine L3 support: false"
-            )
-            DRMCheckItem(
-                drmName = "ClearKey",
-                isSupported = true,
-                details = "ClearKey CDM is present."
-            )
-            DRMCheckItem(
-                drmName = "PlayReady",
-                isSupported = false,
-                details = "PlayReady is NOT supported on this device."
-            )
-        }
     }
+}
 
+@Preview(showBackground = true)
+@Composable
+fun DRMInfoContentPreview() {
+    CheckDrmInfoTheme {
+        DRMInfoContent(
+            modifier = Modifier,
+            widevineInfo = Pair(true, "Security Level: L1\nWidevine L1 support: true\nWidevine L2 support: false\nWidevine L3 support: false"),
+            clearKeyInfo = Pair(true, "ClearKey CDM is present."),
+            playReadyInfo = Pair(false, "PlayReady is NOT supported on this device."),
+            deviceInfo = DeviceInfo("Pixel 7", "Google", "14", 34, "google/cheetah/cheetah:14/UP1A.231005.007/10754064:user/release-keys")
+        )
+    }
 }

--- a/app/src/main/java/com/example/checkdrminfo/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/checkdrminfo/ui/theme/Color.kt
@@ -2,10 +2,10 @@ package com.example.checkdrminfo.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+val Orange80 = Color(0xFFFFDAB9) // Light Orange
+val LightOrange80 = Color(0xFFF5E6CC) // Light Warm Grey
+val Terracotta80 = Color(0xFFE2A38A) // Light Terracotta
 
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+val Orange40 = Color(0xFFD2691E) // Dark Orange (Chocolate)
+val DarkOrange40 = Color(0xFF8B4513) // Dark Warm Grey (SaddleBrown)
+val DarkTerracotta40 = Color(0xFFA0522D) // Dark Terracotta (Sienna)

--- a/app/src/main/java/com/example/checkdrminfo/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/checkdrminfo/ui/theme/Theme.kt
@@ -12,15 +12,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
+    primary = Orange80,
+    secondary = LightOrange80,
+    tertiary = Terracotta80
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
+    primary = Orange40,
+    secondary = DarkOrange40,
+    tertiary = DarkTerracotta40
 
     /* Other default colors to override
     background = Color(0xFFFFFBFE),

--- a/app/src/test/java/com/example/checkdrminfo/DeviceInfoTest.kt
+++ b/app/src/test/java/com/example/checkdrminfo/DeviceInfoTest.kt
@@ -1,0 +1,36 @@
+package com.example.checkdrminfo
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DeviceInfoTest {
+
+    @Test
+    fun `DeviceInfo default values are set correctly`() {
+        // Since we can't easily mock android.os.Build in unit tests without a library like Robolectric
+        // or using mockkStatic (which is complex for Build), we'll test the data class construction.
+        val deviceInfo = DeviceInfo(
+            model = "TestModel",
+            manufacturer = "TestManufacturer",
+            androidVersion = "12",
+            sdkInt = 31,
+            fingerprint = "test/fingerprint",
+        )
+
+        assertEquals("TestModel", deviceInfo.model)
+        assertEquals("TestManufacturer", deviceInfo.manufacturer)
+        assertEquals("12", deviceInfo.androidVersion)
+        assertEquals(31, deviceInfo.sdkInt)
+        assertEquals("test/fingerprint", deviceInfo.fingerprint)
+    }
+
+    @Test
+    fun `DRMInfoState default values are correctly initialized`() {
+        val state = DRMInfoState()
+        assertEquals(null, state.widevineInfo)
+        assertEquals(null, state.clearKeyInfo)
+        assertEquals(null, state.playReadyInfo)
+        // Check that DeviceInfo is also initialized without crashing
+        assertEquals("Unknown", state.deviceInfo.model)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,12 @@
 [versions]
-agp = "8.10.1"
+agp = "8.13.0"
 kotlin = "2.1.10"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.7"
+lifecycleViewmodelCompose = "2.10.0"
 activityCompose = "1.10.0"
 composeBom = "2025.02.00"
 media3Common = "1.5.1"
@@ -20,6 +21,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.10.0-alpha03"
+agp = "8.10.1"
 kotlin = "2.1.10"
 coreKtx = "1.15.0"
 junit = "4.13.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Feb 03 11:30:37 PST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,9 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+}
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
Refactored to DRMViewModel: Migrated state management from remember blocks to a ViewModel for better scalability and testability.
•Changing theme.
•Added Device Info: Implemented a new section that displays key device details, including the fingerprint.
•Added Previews: Created dedicated Compose Previews for the new components (DeviceInfoSectionPreview, DRMInfoContentPreview).
•Added Unit Tests: Created DeviceInfoTest.kt to ensure correct initialization and fixed initialization issues in unit tests by adding safety around android.os.Build calls.
•Code Clean-up: Addressed lint issues, improved naming conventions, and refactored the DRMChecker class.
•Updated .gitignore: Replaced the project's .gitignore with a standard Android template to exclude IDE-specific and build-generated files.
